### PR TITLE
Switch to using pycord, change rocode command to be a slash command

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 import os
 import json
-from discord.ext import commands
-import discord
+# noinspection PyPackageRequirements
+from discord.ext import commands  # 'discord' module comes from 'py-cord' package
+# noinspection PyPackageRequirements
+import discord  # 'discord' module comes from 'py-cord' package
 import logging
 from os.path import exists
 
@@ -10,7 +12,7 @@ from os.path import exists
 FORMAT = ('%(asctime)-15s %(threadName)-15s '
           '%(levelname)-8s %(module)-15s:%(lineno)-8s %(message)s')
 logging.basicConfig(format=FORMAT)
-logger = logging.getLogger('Main')
+logger = logging.getLogger('discord')
 logger.setLevel(logging.INFO)
 
 configFile = 'config.json'
@@ -33,8 +35,7 @@ if not exists('./persistent/events.json'):
         json.dump({}, f)
         f.close()
 
-intents = discord.Intents.default()
-intents.message_content = True
+intents = discord.Intents.default() | discord.Intents.message_content
 
 bot = commands.Bot(command_prefix='!', description=description, intents=intents,
                    owner_id=owner)
@@ -42,6 +43,9 @@ bot.rocode_minute = rocode_minute
 bot.rocode_hour = rocode_hour
 bot.epoch_str = epoch
 bot.timezone_str = timezone
+
+bot.load_extension('rocode')
+bot.load_extension('event_threads')
 
 
 async def check_owner(ctx: commands.Context) -> bool:
@@ -51,8 +55,6 @@ async def check_owner(ctx: commands.Context) -> bool:
 @bot.event
 async def on_ready() -> None:
     logger.info(f'Logged in as {bot.user.name} {bot.user.id} \n-----')
-    await bot.load_extension('rocode')
-    await bot.load_extension('event_threads')
 
 if __name__ == '__main__':
     bot.run(discord_token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp
 async-timeout
 attrs
 chardet
-discord.py
+py-cord
 idna
 multidict
 pip

--- a/rocode.py
+++ b/rocode.py
@@ -2,18 +2,17 @@ import datetime
 import pytz
 import random
 # noinspection PyPackageRequirements
-import discord  # 'discord' module comes from 'discord.py' package
+import discord  # 'discord' module comes from 'py-cord' package
+# noinspection PyPackageRequirements
+from discord.ext import commands  # 'discord' module comes from 'py-cord' package
 import logging
-
 from random import shuffle
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-# noinspection PyPackageRequirements
-from discord.ext import commands  # 'discord' module comes from 'discord.py' package
 
 FORMAT = ('%(asctime)-15s %(threadName)-15s '
           '%(levelname)-8s %(module)-15s:%(lineno)-8s %(message)s')
 logging.basicConfig(format=FORMAT)
-logger = logging.getLogger('RoCode')
+logger = logging.getLogger('discord')
 logger.setLevel(logging.INFO)
 
 
@@ -67,15 +66,15 @@ class Rocode(commands.Cog):
                 logger.warning("Could not send ro'code, HTTP error", exc_info=err)
 
     # Users can manually retrieve the current rocode using this command in discord
-    @commands.command(pass_context=True)
+    @commands.slash_command(name='rocode', description='Get today\'s rocode')
     async def rocode(self, ctx: commands.Context) -> None:
         curr_code = self.codes[(datetime.datetime.now(tz=self.tz) - self.epoch).days % len(self.codes)]
-        await ctx.channel.send("Today's Rover Code is:\n\n" + curr_code)
+        await ctx.response.send_message("Today's Rover Code is:\n\n" + curr_code)
 
 
-async def setup(bot: commands.Bot) -> None:
-    await bot.add_cog(Rocode(bot))
+def setup(bot: commands.Bot) -> None:
+    bot.add_cog(Rocode(bot))
 
 
-async def teardown(bot: commands.Bot) -> None:
-    await bot.remove_cog('Rocode')
+def teardown(bot: commands.Bot) -> None:
+    bot.remove_cog('Rocode')


### PR DESCRIPTION
discord.py has some issues with `on_scheduled_event_user_add` and `on_scheduled_event_user_remove` firing because of user caching. py-cord has raw events that solve this issue. I made all the necessary changes and re-tested the relevant events to make sure everything still worked properly. This PR includes only the changes necessary to move from discord.py to py-cord. Once it is merged, I will add the subscription event handlers.